### PR TITLE
Don't modify script nodes with text/html type

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -64,7 +64,8 @@ const META = {
 const SCRIPT_TYPES = {
   'application/javascript': 'js',
   'text/javascript': 'js',
-  'application/json': false
+  'application/json': false,
+  'text/html': false
 };
 
 // Options to be passed to `addURLDependency` for certain tags + attributes


### PR DESCRIPTION
Knockout.js uses <script type="text/html> for named templates. Currently, the type attribute is stripped by parcel. This change prevents that from happening.